### PR TITLE
Add AGENTS.md with development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Cursor Cloud specific instructions
+
+This is a single Next.js 16 application ("Is Colorado on Fire?") with no database, no Docker, and no external secrets required. See `README.md` for standard dev commands.
+
+**Key commands** (all via npm scripts in `package.json`):
+- Dev server: `npm run dev` (Turbopack, port 3000)
+- Lint: `npm run lint` (Biome)
+- Build: `npm run build`
+
+**Runtime notes:**
+- The `/fires` API route fetches live data from `https://inciweb.wildfire.gov/incidents/rss.xml` — requires internet access.
+- Mapbox GL uses a hardcoded public access token in `app/page.tsx`; no environment variable needed.
+- Node.js 22 is required (`.nvmrc` and `engines` field).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future agents working in this repository.

## What was set up

- **Node.js 22** (already available via nvm)
- **npm install** for all dependencies (Next.js 16, React 19, Mapbox GL, Biome, TypeScript 6)
- **Update script**: `npm install` (minimal, idempotent)

## Verification

All checks pass and the application runs correctly:

| Check | Status |
|---|---|
| `npm run lint` (Biome) | ✅ Pass |
| `npm run build` (Next.js) | ✅ Pass |
| `npm run dev` (dev server) | ✅ Running on port 3000 |
| `/fires` API endpoint | ✅ Returns live wildfire data |
| Map UI with fire markers | ✅ Renders and interactive |

### Demo

[demo_colorado_fire_map.mp4](https://cursor.com/agents/bc-2057fb17-063c-4727-92ea-ad9af743936f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_colorado_fire_map.mp4)

The map loads Colorado with active fire markers from InciWeb, and clicking a marker shows fire details in a popup.

[Map full view with fire markers](https://cursor.com/agents/bc-2057fb17-063c-4727-92ea-ad9af743936f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmap_full_view.webp)
[Fire popup showing details](https://cursor.com/agents/bc-2057fb17-063c-4727-92ea-ad9af743936f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffire_popup_detail.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2057fb17-063c-4727-92ea-ad9af743936f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2057fb17-063c-4727-92ea-ad9af743936f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

